### PR TITLE
Replace ncipollo/release-action with softprops/action-gh-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: "CI"
 run-name: |
   ${{
-    (github.event_name == 'pull_request' && format('Test PR "{0}"', github.event.pull_request.title)) ||
+    (github.event_name == 'pull_request' && format('Test PR #{0}', github.event.pull_request.number)) ||
     (github.ref_name == github.event.repository.default_branch && 'Release') ||
     format('Test branch "{0}"', github.ref_name)
   }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,11 @@ jobs:
       - name: "Extract release notes for ${{ inputs.release_name }}"
         env:
           RELEASE_NAME: "${{ inputs.release_name }}"
-        run: 'awk "/^## .*$RELEASE_NAME/ { flag=1; next } /^## / { flag=0 } flag" CHANGELOG.md > release-notes.txt'
+        run: |
+          awk "/^## .*$RELEASE_NAME/ { flag=1; next } /^## / { flag=0 } flag" CHANGELOG.md > release-notes.txt
+          if [ -z "$(grep -vE '^$' release-notes.txt || echo)" ]; then
+            echo "No changes since last release" > release-notes.txt
+          fi
 
       - name: "Remove old version of release"
         if: "${{ inputs.release_name == 'latest' }}"
@@ -33,13 +37,10 @@ jobs:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Create release"
-        uses: "ncipollo/release-action@v1"
+        uses: "softprops/action-gh-release@v2"
         with:
-          tag: "${{ inputs.release_name }}"
-          bodyFile: "release-notes.txt"
-          artifacts: "build/out/sdvg-*"
-          draft: false
-          prerelease: false
-          makeLatest: "${{ inputs.release_name == 'latest' }}"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: "${{ inputs.release_name }}"
+          body_path: "release-notes.txt"
+          files: "build/out/sdvg-*"
+          prerelease: "${{ inputs.release_name == 'latest' }}"
+          make_latest: "${{ inputs.release_name != 'latest' }}"


### PR DESCRIPTION
ncipollo/release-action was frequently creating draft releases unintentionally, which disrupted the release flow.

Switched to softprops/action-gh-release for more reliable and predictable GitHub release creation.