### PR TITLE
Partition docs

### DIFF
--- a/doc/en/usage.md
+++ b/doc/en/usage.md
@@ -100,7 +100,7 @@ The `models[*]` structure describes a data generation model and includes:
 - `generate_to`: Ending row number for generation. Default is `rows_count`.
 - `model_dir`: Directory to store data for this model, relative to `output_dir`. Defaults to model name.
 - `columns`: List of columns described by the `models[*].columns` structure.
-- `partition_columns`: Columns used for data partitioning. Supported only for `parquet`.
+- `partition_columns`: Columns used for data partitioning. Supported for `parquet` and `csv`.
 
 The `models[*].partition_columns` structure specifies data partitioning columns:
 
@@ -345,6 +345,13 @@ models:
         type: uuid
       - name: session_id
         type: string
+      - name: last_seen_at
+        type: datetime
+    partition_columns:
+      - name: id
+        write_to_output: false
+      - name: session_id
+        write_to_output: false
 ```
 
 Example configuration for generating Parquet files:
@@ -368,6 +375,9 @@ models:
         parquet:
           encoding: RLE_DICTIONARY
         distinct_percentage: 1
+    partition_columns:
+      - name: id
+        write_to_output: true
 ```
 
 Example configuration for sending generated data via HTTP:

--- a/doc/ru/usage.md
+++ b/doc/ru/usage.md
@@ -104,7 +104,7 @@ open_ai:
 - `model_dir`: Директория для записи сгенерированных данных конкретной модели относительно `output_dir`.
   По умолчанию название модели.
 - `columns`: Список столбцов модели данных, описанных структурой `models[*].columns`.
-- `partition_columns`: Список столбцов, участвующих в партиционировании данных. Поддерживается только для `parquet`.
+- `partition_columns`: Список столбцов, участвующих в партиционировании данных. Поддерживается для `parquet` и `csv`.
 
 Структура `models[*].partition_columns` описывает как столбец участвует в партиционировании данных:
 
@@ -351,6 +351,13 @@ models:
         type: uuid
       - name: session_id
         type: string
+      - name: last_seen_at
+        type: datetime
+    partition_columns:
+      - name: id
+        write_to_output: false
+      - name: session_id
+        write_to_output: false
 ```
 
 Пример конфигурации для генерации parquet файлов:
@@ -374,6 +381,9 @@ models:
         parquet:
           encoding: RLE_DICTIONARY
         distinct_percentage: 1
+    partition_columns:
+      - name: id
+        write_to_output: true
 ```
 
 Пример конфигурации для отправки сгенерированных данных по http:


### PR DESCRIPTION
This pull request updates the documentation by adding the use of `partition_columns` to the configuration examples and indicating that this parameter can also be used in csv output type.