### PR TITLE
Prevent shell command execution from commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
             exit 0
           fi
 
-          VERSION=$(echo "${{ github.event.head_commit.message }}" \
-            | sed -nE 's/.*[Rr]elease ([0-9]+\.[0-9]+\.[0-9]+).*?/\1/p')
+          VERSION=$(git log -1 --pretty=%B | sed -nE 's/.*[Rr]elease ([0-9]+\.[0-9]+\.[0-9]+).*?/\1/p')
 
           if [ -z "${VERSION}" ]; then
             echo "No semantic version found in commit message"


### PR DESCRIPTION
Previously, commit messages were passed via a variable, which allowed embedded shell commands (e.g. `$(...)`) to be executed during parsing. For example, this happened in this run: https://github.com/tarantool/sdvg/actions/runs/16798902022/job/47575402000

Now the message is fetched directly via `git` and safely piped through `sed`, ensuring arbitrary code is not executed.