### PR TITLE
Specify branch for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 [release-url]: https://github.com/tarantool/sdvg/releases/latest/
 [pre-release-badge]: https://badgen.net/static/pre-release/latest/orange?color=purple
 [pre-release-url]: https://github.com/tarantool/sdvg/releases/tag/latest/
-[actions-badge]: https://badgen.net/github/checks/tarantool/sdvg
+[actions-badge]: https://badgen.net/github/checks/tarantool/sdvg/master
 [actions-url]: https://github.com/tarantool/sdvg/actions
-[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg
+[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg/master
 [test-coverage-url]: https://coveralls.io/github/tarantool/sdvg?branch=master
 [language-badge]: https://badgen.net/static/language/go/blue
 [language-url]: https://github.com/tarantool/sdvg/search?l=go

--- a/README.ru.md
+++ b/README.ru.md
@@ -15,9 +15,9 @@
 [release-url]: https://github.com/tarantool/sdvg/releases/latest/
 [pre-release-badge]: https://badgen.net/static/pre-release/latest/orange?color=purple
 [pre-release-url]: https://github.com/tarantool/sdvg/releases/tag/latest/
-[actions-badge]: https://badgen.net/github/checks/tarantool/sdvg
+[actions-badge]: https://badgen.net/github/checks/tarantool/sdvg/master
 [actions-url]: https://github.com/tarantool/sdvg/actions
-[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg
+[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg/master
 [test-coverage-url]: https://coveralls.io/github/tarantool/sdvg?branch=master
 [language-badge]: https://badgen.net/static/language/go/blue
 [language-url]: https://github.com/tarantool/sdvg/search?l=go


### PR DESCRIPTION
Before the patch, the badges would sometimes show error 500.

Now the branch is specified so that the error does not occur.