### PR TITLE
Remove Coveralls integration due to outages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
 env:
   GIT_CONFIG_GLOBAL: "/root/.gitconfig" # fix path in container (https://github.com/actions/runner/issues/2033)
 
+defaults:
+  run:
+    shell: "bash"
+
 jobs:
 
   ### LINT ###
@@ -47,14 +51,16 @@ jobs:
       - uses: "actions/checkout@v4"
 
       - name: "Measuring test coverage"
-        run: "make test/cover"
+        run: "make test/cover | tee coverage.log; exit ${PIPESTATUS[0]}"
 
-      - name: "Upload coverage to Coveralls"
-        uses: "coverallsapp/github-action@v2"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: "coverage.out"
-          format: "golang"
+      - name: "Upload coverage to badge"
+        if: "${{ github.ref_name == github.event.repository.default_branch }}"
+        env:
+          BADGEN_TOKEN: ${{ secrets.BADGEN_TOKEN }}
+        run: |
+          RESULT=$(grep -E 'total:\s+\(statements\)\s+[0-9]+\.[0-9]+%' coverage.log | grep -Eo '[0-9]+\.[0-9]+%' | sed 's/%/%25/g')
+          curl -LX PUT --header "Authorization: Bearer ${BADGEN_TOKEN}" \
+            "https://badgen.net/memo/tarantool-sdvg-coverage-master/coverage/${RESULT}/green"
 
   ### PERFORMANCE ###
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 [pre-release-badge]: https://badgen.net/static/pre-release/latest/orange?color=purple
 [pre-release-url]: https://github.com/tarantool/sdvg/releases/tag/latest/
 [actions-badge]: https://badgen.net/github/checks/tarantool/sdvg/master
-[actions-url]: https://github.com/tarantool/sdvg/actions
-[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg/master
-[test-coverage-url]: https://coveralls.io/github/tarantool/sdvg?branch=master
+[actions-url]: https://github.com/tarantool/sdvg/actions?query=branch%3Amaster
+[test-coverage-badge]: https://badgen.net/memo/tarantool-sdvg-coverage-master
+[test-coverage-url]: https://github.com/tarantool/sdvg/actions?query=branch%3Amaster
 [language-badge]: https://badgen.net/static/language/go/blue
 [language-url]: https://github.com/tarantool/sdvg/search?l=go
 [license-badge]: https://badgen.net/github/license/tarantool/sdvg?color=cyan

--- a/README.ru.md
+++ b/README.ru.md
@@ -16,9 +16,9 @@
 [pre-release-badge]: https://badgen.net/static/pre-release/latest/orange?color=purple
 [pre-release-url]: https://github.com/tarantool/sdvg/releases/tag/latest/
 [actions-badge]: https://badgen.net/github/checks/tarantool/sdvg/master
-[actions-url]: https://github.com/tarantool/sdvg/actions
-[test-coverage-badge]: https://badgen.net/coveralls/c/github/tarantool/sdvg/master
-[test-coverage-url]: https://coveralls.io/github/tarantool/sdvg?branch=master
+[actions-url]: https://github.com/tarantool/sdvg/actions?query=branch%3Amaster
+[test-coverage-badge]: https://badgen.net/memo/tarantool-sdvg-coverage-master
+[test-coverage-url]: https://github.com/tarantool/sdvg/actions?query=branch%3Amaster
 [language-badge]: https://badgen.net/static/language/go/blue
 [language-url]: https://github.com/tarantool/sdvg/search?l=go
 [license-badge]: https://badgen.net/github/license/tarantool/sdvg?color=cyan


### PR DESCRIPTION
Before this patch, the project reported code coverage to Coveralls after each build, but the service’s outages caused CI failures.

After this patch, all Coveralls-related configuration, dependencies, and CI steps have been removed to ensure builds run reliably without external coverage reporting interruptions.