### PR TITLE
Fix secrets usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
   test:
     needs: ["create-semantic-tag"]
     uses: "./.github/workflows/test.yml"
+    secrets: "inherit"
 
   build:
     needs: ["test"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,9 @@ jobs:
 
       - name: "Upload coverage to badge"
         if: "${{ github.ref_name == github.event.repository.default_branch }}"
-        env:
-          BADGEN_TOKEN: ${{ secrets.BADGEN_TOKEN }}
         run: |
           RESULT=$(grep -E 'total:\s+\(statements\)\s+[0-9]+\.[0-9]+%' coverage.log | grep -Eo '[0-9]+\.[0-9]+%' | sed 's/%/%25/g')
-          curl -LX PUT --header "Authorization: Bearer ${BADGEN_TOKEN}" \
+          curl -LX PUT --header "Authorization: Bearer ${{ secrets.BADGEN_TOKEN }}" \
             "https://badgen.net/memo/tarantool-sdvg-coverage-master/coverage/${RESULT}/green"
 
   ### PERFORMANCE ###


### PR DESCRIPTION
For security reasons, secrets are not automatically passed to reusable workflows:
https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow

This patch enables passing secrets to workflow with tests.