### PR TITLE
Add permissions to GH Actions for commenting PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
           message-path: "performance-report.md"
           message-id: "perf-report-pr-${{ github.event.pull_request.number }}"
           refresh-message-position: true
+          repo-token: "${{ secrets.PR_TOKEN }}"
 
       - name: "Prepare master benchmark info for uploading as artifact"
         if: "${{ github.ref_name == github.event.repository.default_branch }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
       BENCH_MASTER_SHA_FILE_PATH: "bench-master-info/benchmark-master-sha.txt"
     container:
       image: "ghcr.io/tarantool/sdvg-ci:0.0.2"
+    permissions:
+      pull-requests: "write"
+      packages: "read"
 
     steps:
       - uses: "actions/checkout@v4"
@@ -104,7 +107,6 @@ jobs:
           message-path: "performance-report.md"
           message-id: "perf-report-pr-${{ github.event.pull_request.number }}"
           refresh-message-position: true
-          repo-token: "${{ secrets.PR_TOKEN }}"
 
       - name: "Prepare master benchmark info for uploading as artifact"
         if: "${{ github.ref_name == github.event.repository.default_branch }}"


### PR DESCRIPTION
Prior to this patch, it was impossible to see the perf testing report in a PR comments, since github_token did not grant write permissions for fork repositories.