### PR TITLE
FIX Output.Teardown bug

### DIFF
--- a/internal/generator/output/general/test/unit_test.go
+++ b/internal/generator/output/general/test/unit_test.go
@@ -296,7 +296,7 @@ func TestWriterInitTeardown(t *testing.T) {
 		{
 			"parquet",
 			outputParquet.NewWriter(
-				nil,
+				&models.Model{Columns: make([]*models.Column, 0)},
 				&models.ParquetConfig{
 					"UNCOMPRESSED",
 					2,

--- a/internal/generator/output/general/test/unit_test.go
+++ b/internal/generator/output/general/test/unit_test.go
@@ -267,7 +267,7 @@ cause: dir for model is not empty
 	}
 }
 
-// TestWriterInitTeardown tests if Teardown works properly right after Init
+// TestWriterInitTeardown tests if Teardown works properly right after Init.
 func TestWriterInitTeardown(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -280,7 +280,6 @@ func TestWriterInitTeardown(t *testing.T) {
 			outputCsv.NewWriter(
 				context.TODO(),
 				nil,
-				//w.config.CSVParams,
 				&models.CSVConfig{
 					FloatPrecision: 1,
 					DatetimeFormat: "2006-01-02T15:04:05Z07:00",
@@ -298,9 +297,9 @@ func TestWriterInitTeardown(t *testing.T) {
 			outputParquet.NewWriter(
 				&models.Model{Columns: make([]*models.Column, 0)},
 				&models.ParquetConfig{
-					"UNCOMPRESSED",
-					2,
-					models.ParquetDateTimeMillisFormat,
+					CompressionCodec: "UNCOMPRESSED",
+					FloatPrecision:   2,
+					DateTimeFormat:   models.ParquetDateTimeMillisFormat,
 				},
 				nil,
 				outputParquet.NewFileSystem(),

--- a/internal/generator/output/general/test/unit_test.go
+++ b/internal/generator/output/general/test/unit_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/tarantool/sdvg/internal/generator/common"
 	"github.com/tarantool/sdvg/internal/generator/models"
 	outputGeneral "github.com/tarantool/sdvg/internal/generator/output/general"
+	"github.com/tarantool/sdvg/internal/generator/output/general/writer"
+	outputCsv "github.com/tarantool/sdvg/internal/generator/output/general/writer/csv"
+	outputParquet "github.com/tarantool/sdvg/internal/generator/output/general/writer/parquet"
 	"github.com/tarantool/sdvg/internal/generator/usecase"
 	useCaseGeneral "github.com/tarantool/sdvg/internal/generator/usecase/general"
 )
@@ -260,6 +263,58 @@ cause: dir for model is not empty
 			}
 
 			require.NoError(t, os.RemoveAll(models.DefaultOutputDir))
+		})
+	}
+}
+
+// TestWriterInitTeardown tests if Teardown works properly right after Init
+func TestWriterInitTeardown(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		name   string
+		writer writer.Writer
+	}{
+		{
+			"csv",
+			outputCsv.NewWriter(
+				context.TODO(),
+				nil,
+				//w.config.CSVParams,
+				&models.CSVConfig{
+					FloatPrecision: 1,
+					DatetimeFormat: "2006-01-02T15:04:05Z07:00",
+					Delimiter:      ",",
+					WithoutHeaders: false,
+				},
+				nil,
+				tmpDir,
+				false,
+				make(chan<- uint64),
+			),
+		},
+		{
+			"parquet",
+			outputParquet.NewWriter(
+				nil,
+				&models.ParquetConfig{
+					"UNCOMPRESSED",
+					2,
+					models.ParquetDateTimeMillisFormat,
+				},
+				nil,
+				outputParquet.NewFileSystem(),
+				tmpDir,
+				false,
+				make(chan<- uint64),
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tc.writer.Init())
+			require.NoError(t, tc.writer.Teardown())
 		})
 	}
 }

--- a/internal/generator/output/general/writer/csv/csv.go
+++ b/internal/generator/output/general/writer/csv/csv.go
@@ -435,16 +435,11 @@ func (w *Writer) Teardown() error {
 	close(w.flushStopChan)
 	w.flushWg.Wait()
 
-	w.writerMutex.Lock()
 	if w.csvWriter != nil {
-		w.writerMutex.Unlock()
-
 		if err := w.flush(); err != nil {
 			return err
 		}
 	}
-
-	w.writerMutex.TryLock()
 
 	if w.fileDescriptor != nil {
 		if err := w.fileDescriptor.Close(); err != nil {

--- a/internal/generator/output/general/writer/csv/csv.go
+++ b/internal/generator/output/general/writer/csv/csv.go
@@ -438,12 +438,14 @@ func (w *Writer) Teardown() error {
 	w.writerMutex.Lock()
 	if w.csvWriter != nil {
 		w.writerMutex.Unlock()
+
 		if err := w.flush(); err != nil {
 			return err
 		}
 	}
 
 	w.writerMutex.TryLock()
+
 	if w.fileDescriptor != nil {
 		if err := w.fileDescriptor.Close(); err != nil {
 			return errors.New(err.Error())

--- a/internal/generator/output/general/writer/csv/csv.go
+++ b/internal/generator/output/general/writer/csv/csv.go
@@ -436,13 +436,14 @@ func (w *Writer) Teardown() error {
 	w.flushWg.Wait()
 
 	w.writerMutex.Lock()
-	defer w.writerMutex.Unlock()
 	if w.csvWriter != nil {
+		w.writerMutex.Unlock()
 		if err := w.flush(); err != nil {
 			return err
 		}
 	}
 
+	w.writerMutex.TryLock()
 	if w.fileDescriptor != nil {
 		if err := w.fileDescriptor.Close(); err != nil {
 			return errors.New(err.Error())

--- a/internal/generator/output/general/writer/parquet/parquet.go
+++ b/internal/generator/output/general/writer/parquet/parquet.go
@@ -29,7 +29,7 @@ import (
 const (
 	flushInterval = 5 * time.Second
 	//nolint:godox
-	// TODO: find optimal value, or calculate it to flush on disk 512Mb data
+	// TODO: find optimal value, or calculate it to flush on disk 512Mb data.
 	recordBuilderReserve = 5000
 )
 
@@ -672,12 +672,14 @@ func (w *Writer) Teardown() error {
 	w.writerMutex.Lock()
 	if w.recordBuilder != nil && w.parquetWriter != nil {
 		w.writerMutex.Unlock()
+
 		if err := w.flush(); err != nil {
 			return errors.New(err.Error())
 		}
 	}
 
 	w.writerMutex.TryLock()
+
 	if w.parquetWriter != nil {
 		if err := w.parquetWriter.Close(); err != nil {
 			return errors.New(err.Error())


### PR DESCRIPTION
## Fix: Safe `Teardown` Before First `WriteRow`  

Previously, calling `Teardown` on a `dataWriter` **before the first `WriteRow`** caused a panic.  
The issue occurred because the underlying writer (CSV or Parquet) was never initialized, yet `Teardown` attempted to flush it.  

### Example of failing flow
```go
dataWriter := csv.NewWriter(
    ctx,
    w.model,
    w.config.CSVParams,
    w.columnsToDiscard,
    outPath,
    w.continueGeneration,
    w.writtenRowsChan,
)

dataWriter.Init()
dataWriter.Teardown() // panic here
```

### Changes in this PR
- Fixed `Teardown` implementation for **CSV** and **Parquet** writers to handle cases when no rows were written.
- Added a **unit test** that reproduces the bug and verifies the fix.  
