### PR TITLE
New workflow for commenting pr

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,5 +1,5 @@
 name: "Comment PR"
-run-name: "${{ format('Comment PR #{0}', github.event.pull_request.number)) }}"
+run-name: "${{ format('Comment PR #{0}', github.event.pull_request.number) }}"
 
 on:
   pull_request_target:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,4 +1,5 @@
 name: "Comment PR"
+run-name: "${{ format('Comment PR #{0}', github.event.pull_request.number)) }}"
 
 on:
   pull_request_target:
@@ -12,7 +13,7 @@ env:
 
 jobs:
 
-  add-comment:
+  perf-report:
     runs-on: "ubuntu-latest"
 
     steps:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,48 @@
+name: "Comment PR"
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: "write"
+  contents: "read"
+
+env:
+  GIT_CONFIG_GLOBAL: "/root/.gitconfig" # fix path in container (https://github.com/actions/runner/issues/2033)
+
+jobs:
+
+  add-comment:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Wait for performance job to succeed"
+        uses: "fountainhead/action-wait-for-check@v1.2.0"
+        id: "wait-for-perf"
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "test / performance"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - if: steps.wait-for-perf.outputs.conclusion != 'success'
+        run: |
+          echo "Perf tests job failed, stopping workflow."
+          exit 1
+
+      - name: "Download benchmark report"
+        uses: "dawidd6/action-download-artifact@v11"
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          commit: "${{ github.event.pull_request.head.sha }}"
+          if_no_artifact_found: "fail"
+          workflow: "ci.yml"
+          workflow_conclusion: "" # to ignore status or conclusion in the search
+          allow_forks: true # searching artifact in forks
+          name: "perf-report"
+          path: "./"
+
+      - uses: "mshick/add-pr-comment@v2"
+        with:
+          message-path: "performance-report.md"
+          message-id: "perf-report-pr-${{ github.event.pull_request.number }}"
+          refresh-message-position: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
   ### PERFORMANCE ###
 
   performance:
+    name: "performance"
     runs-on: "ubuntu-latest"
     env:
       BENCH_MASTER_ARTIFACT_KEY: "bench-master"
@@ -98,12 +99,11 @@ jobs:
 
           cat performance-report.md >> $GITHUB_STEP_SUMMARY
 
-      - uses: "mshick/add-pr-comment@v2"
-        if: "${{ github.event_name == 'pull_request' }}"
+      - name: "Upload perf comparison report as artifact"
+        uses: "actions/upload-artifact@v4"
         with:
-          message-path: "performance-report.md"
-          message-id: "perf-report-pr-${{ github.event.pull_request.number }}"
-          refresh-message-position: true
+          name: "perf-report"
+          path: "performance-report.md"
 
       - name: "Prepare master benchmark info for uploading as artifact"
         if: "${{ github.ref_name == github.event.repository.default_branch }}"


### PR DESCRIPTION
PR adds a new workflow pr-comment.yml triggered on pull_request_target that:
- Waits for the successful completion of the performance job in the main CI workflow.
- Downloads the perf-report artifact generated by the performance job.
- Posts or updates a PR comment with the content of performance-report.md.

Prior to this patch, CI's `test/performance` job could not publish the `perf-report` as a comment in a Pull request from forked repositories due to write restrictions for `GITHUB_TOKEN`.

The `pull_request_target` event grants the necessary rights, which is why the publication of the `perf-report` was moved to a separate workflow.